### PR TITLE
Fix message bus not including deleted

### DIFF
--- a/lib/collections/initializers/add_topic_extensions.rb
+++ b/lib/collections/initializers/add_topic_extensions.rb
@@ -26,23 +26,15 @@ module ::Collections
           custom_fields[Collections::SUBCOLLECTION_ID] = value
         end
 
-        plugin.add_to_serializer(
-          :topic_view,
-          Collections::COLLECTION.to_sym,
-          include_condition: -> { topic.public_send(Collections::COLLECTION_ID) },
-        ) do
+        plugin.add_to_serializer(:topic_view, Collections::COLLECTION.to_sym) do
+          return nil if topic.public_send(Collections::COLLECTION_ID).blank?
           collection = Collections::Collection.find(topic.public_send(Collections::COLLECTION_ID))
-          return nil if collection.blank?
           Collections::CollectionSerializer.new(collection, scope: scope, root: false)
         end
 
-        plugin.add_to_serializer(
-          :topic_view,
-          Collections::SUBCOLLECTION.to_sym,
-          include_condition: -> { topic.public_send(Collections::SUBCOLLECTION_ID) },
-        ) do
+        plugin.add_to_serializer(:topic_view, Collections::SUBCOLLECTION.to_sym) do
+          return nil if topic.public_send(Collections::SUBCOLLECTION_ID).blank?
           sub = Collections::Collection.find(topic.public_send(Collections::SUBCOLLECTION_ID))
-          return nil if sub.blank?
           Collections::CollectionSerializer.new(sub, scope: scope, root: false)
         end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,7 +3,7 @@
 # name: discourse-collections
 # about: Discourse Collections Plugin
 # meta_topic_id: TODO
-# version: 1.0.0
+# version: 1.0.1
 # authors: Alteras1
 # url: https://github.com/Alteras1/discourse-collections
 # required_version: 3.4.0


### PR DESCRIPTION
This fixes an issue where deleting collections or collection items does not update the appropriate pages.

As part of solution, change the serializer to always have the `collection` and `subcollection` field, as the `Topic` model currently is unable to handle deleting fields from JSON response