### PR TITLE
Add separate subcollection owner group permissions

### DIFF
--- a/app/controllers/collections/collections_controller.rb
+++ b/app/controllers/collections/collections_controller.rb
@@ -44,7 +44,7 @@ module ::Collections
           collection.user_id = topic.user_id
         end
 
-        raise Discourse::InvalidAccess unless guardian.can_create_collection_for_topic?(topic)
+        raise Discourse::InvalidAccess unless guardian.can_create_subcollection_for_topic?(topic)
         collection.transaction do
           collection.save!
           Collections::CollectionHandler.attach_subcollection_to_topic(topic, collection)

--- a/assets/javascripts/discourse/components/collection-post-menu-button.gjs
+++ b/assets/javascripts/discourse/components/collection-post-menu-button.gjs
@@ -47,12 +47,18 @@ export default class CollectionPostMenuButton extends Component {
     return this.args.post.topic.can_create_collection;
   }
 
+  get canCreateSubcollection() {
+    return this.args.post.topic.can_create_subcollection;
+  }
+
   get canManageCollection() {
     return this.canCreate || this.collection?.can_edit_collection;
   }
 
   get canManageSubcollection() {
-    return this.canCreate || this.subcollection?.can_edit_collection;
+    return (
+      this.canCreateSubcollection || this.subcollection?.can_edit_collection
+    );
   }
 
   @bind

--- a/assets/javascripts/discourse/components/collection-sidebar-footer.gjs
+++ b/assets/javascripts/discourse/components/collection-sidebar-footer.gjs
@@ -22,6 +22,8 @@ export default class CollectionSidebarFooter extends Component {
   @tracked subcollection;
   /** @type {boolean} */
   @tracked canCreate = false;
+  /** @type {boolean} */
+  @tracked canCreateSubcollection = false;
 
   constructor() {
     super(...arguments);
@@ -41,7 +43,9 @@ export default class CollectionSidebarFooter extends Component {
   }
 
   get canManageSubcollection() {
-    return this.canCreate || this.subcollection?.can_edit_collection;
+    return (
+      this.canCreateSubcollection || this.subcollection?.can_edit_collection
+    );
   }
 
   get canManageAnyCollection() {
@@ -70,6 +74,7 @@ export default class CollectionSidebarFooter extends Component {
     this.collection = collection;
     this.subcollection = subcollection;
     this.canCreate = topic?.can_create_collection;
+    this.canCreateSubcollection = topic?.can_create_subcollection;
   }
 
   setValues() {
@@ -78,11 +83,13 @@ export default class CollectionSidebarFooter extends Component {
       this.collection = null;
       this.subcollection = null;
       this.canCreate = false;
+      this.canCreateSubcollection = false;
     } else {
       this.topic = this.router.currentRoute?.parent.attributes;
       this.collection = this.topic?.collection;
       this.subcollection = this.topic?.subcollection;
       this.canCreate = this.topic?.can_create_collection;
+      this.canCreateSubcollection = this.topic?.can_create_subcollection;
     }
   }
 

--- a/assets/javascripts/discourse/initializers/collections.js
+++ b/assets/javascripts/discourse/initializers/collections.js
@@ -54,7 +54,7 @@ export default {
       api.addTopicAdminMenuButton((topic) => {
         const subcollection = topic.get("subcollection");
         const canManageSubcollection =
-          topic.get("can_create_collection") ||
+          topic.get("can_create_subcollection") ||
           subcollection?.can_edit_collection;
 
         if (!canManageSubcollection) {
@@ -112,6 +112,7 @@ export default {
           }
           if (
             post.topic.can_create_collection ||
+            post.topic.can_create_subcollection ||
             post.topic.collection?.can_edit_collection ||
             post.topic.subcollection?.can_edit_collection
           ) {

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -3,6 +3,7 @@ en:
     collections_enabled: "Enable Discourse Collections"
     collection_by_topic_owner: "Allow topic owner to create/edit collections"
     collection_by_topic_owner_allow_groups: "Topic owner must be part of group to create collection. Enabled if collection_by_topic_owner"
+    subcollection_by_topic_owner_allow_groups: "Topic owner must be part of group to create a subcollection. Enabled if collection_by_topic_owner"
     collection_modification_by_allowed_groups: "Allow groups to create/edit any collection on any topic"
     sections_in_subcollection: "Allow section headers in subcollections"
   collections:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,13 @@ discourse_collections:
     refresh: true
     area: "group_permissions"
     client: true
+  subcollection_by_topic_owner_allow_groups:
+    default: "11"
+    type: group_list
+    allow_any: false
+    refresh: true
+    area: "group_permissions"
+    client: true
   collection_modification_by_allowed_groups:
     type: group_list
     list_type: compact

--- a/lib/collections/guardian_extensions.rb
+++ b/lib/collections/guardian_extensions.rb
@@ -17,6 +17,21 @@ module ::Collections
       topic.user_id == current_user.id
     end
 
+    def can_create_subcollection_for_topic?(topic)
+      return false if current_user.nil?
+      if current_user.in_any_groups?(SiteSetting.collection_modification_by_allowed_groups_map)
+        return true
+      end
+
+      return false unless SiteSetting.collection_by_topic_owner
+      unless current_user.in_any_groups?(SiteSetting.subcollection_by_topic_owner_allow_groups_map)
+        return false
+      end
+      return false if topic.blank?
+
+      topic.user_id == current_user.id
+    end
+
     def can_edit_collection?(collection)
       return false if current_user.nil?
       return true if collection.user_id == current_user.id

--- a/lib/collections/initializers/add_topic_extensions.rb
+++ b/lib/collections/initializers/add_topic_extensions.rb
@@ -41,6 +41,10 @@ module ::Collections
         plugin.add_to_serializer(:topic_view, :can_create_collection) do
           scope.can_create_collection_for_topic?(object.topic)
         end
+
+        plugin.add_to_serializer(:topic_view, :can_create_subcollection) do
+          scope.can_create_subcollection_for_topic?(object.topic)
+        end
       end
     end
   end

--- a/spec/requests/collections_controller_spec.rb
+++ b/spec/requests/collections_controller_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Collections::CollectionsController do
 
     it "allows an eligible topic owner to create a subcollection" do
       SiteSetting.subcollection_by_topic_owner_allow_groups = Group::AUTO_GROUPS[:trust_level_1]
+      user.change_trust_level!(TrustLevel[1])
 
       expect do
         post "/collections.json",

--- a/spec/requests/collections_controller_spec.rb
+++ b/spec/requests/collections_controller_spec.rb
@@ -31,6 +31,79 @@ RSpec.describe Collections::CollectionsController do
   describe "#create" do
     before { sign_in(user) }
 
+    it "allows an eligible topic owner to create a subcollection" do
+      SiteSetting.subcollection_by_topic_owner_allow_groups = Group::AUTO_GROUPS[:trust_level_1]
+
+      expect do
+        post "/collections.json",
+             params: {
+               topic_id: create_topic.id,
+               is_single_topic: true,
+               maintainer_ids: [],
+               items: [
+                 {
+                   name: "Related resource",
+                   url: "https://example.com/resource",
+                   position: 0,
+                   is_section_header: false,
+                 },
+               ],
+             },
+             as: :json
+      end.to change(Collections::Collection, :count).by(1)
+
+      expect(response.status).to eq(200)
+      expect(Collections::Collection.order(:id).last).to be_is_single_topic
+    end
+
+    it "forbids a topic owner outside the allowed subcollection groups" do
+      SiteSetting.subcollection_by_topic_owner_allow_groups = Group::AUTO_GROUPS[:trust_level_4]
+
+      expect do
+        post "/collections.json",
+             params: {
+               topic_id: create_topic.id,
+               is_single_topic: true,
+               maintainer_ids: [],
+               items: [
+                 {
+                   name: "Related resource",
+                   url: "https://example.com/resource",
+                   position: 0,
+                   is_section_header: false,
+                 },
+               ],
+             },
+             as: :json
+      end.not_to change(Collections::Collection, :count)
+
+      expect(response.status).to eq(403)
+    end
+
+    it "lets globally allowed groups create a subcollection on another user's topic" do
+      sign_in(Fabricate(:admin))
+
+      expect do
+        post "/collections.json",
+             params: {
+               topic_id: other_users_topic.id,
+               is_single_topic: true,
+               maintainer_ids: [],
+               items: [
+                 {
+                   name: "Related resource",
+                   url: "https://example.com/resource",
+                   position: 0,
+                   is_section_header: false,
+                 },
+               ],
+             },
+             as: :json
+      end.to change(Collections::Collection, :count).by(1)
+
+      expect(response.status).to eq(200)
+    end
+
     it "creates a collection with the current user's topic", :aggregate_failures do
       expect do
         post "/collections.json",

--- a/test/javascripts/acceptance/collection-topic-admin-menu-test.js
+++ b/test/javascripts/acceptance/collection-topic-admin-menu-test.js
@@ -120,6 +120,21 @@ acceptance("Collections | Topic admin menu", function (needs) {
       );
   });
 
+  test("shows only the subcollection button when the user can create subcollections", async function (assert) {
+    updateCurrentUser({ moderator: false, admin: false, trust_level: 1 });
+
+    await visit("/t/topic-for-group-moderators/2480");
+
+    const topic = this.owner.lookup("controller:topic").model;
+    topic.set("can_create_collection", false);
+    topic.set("can_create_subcollection", true);
+
+    await click(".toggle-admin-menu");
+
+    assert.dom(".topic-admin-collections").doesNotExist();
+    assert.dom(".topic-admin-subcollections").exists();
+  });
+
   test("shows collection admin controls for maintainers", async function (assert) {
     updateCurrentUser({
       id: 101,


### PR DESCRIPTION
## What changed

- adds a `subcollection_by_topic_owner_allow_groups` group-list setting
- uses that setting when topic owners create or edit SubCollections
- keeps `collection_by_topic_owner_allow_groups` scoped to regular Collections
- exposes `can_create_subcollection` to the relevant frontend controls
- adds request and acceptance coverage for allowed and disallowed groups

## Why

Site administrators may want to let one set of groups create regular Collections while allowing a different set of groups to attach SubCollections to their own topics. Previously, both actions shared the same group setting.

## Validation

- `git diff --check` passed
- Prettier passed
- Stylelint passed
- Ember type checking passed
- ESLint reaches 7 pre-existing `ember/template-no-nested-interactive` errors in `collection-item-form.gjs`, which is unchanged by this PR